### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/mathieumack/RAG.Parsers/security/code-scanning/1](https://github.com/mathieumack/RAG.Parsers/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to the workflow file.  
The best way is to add the `permissions` key at the workflow root (top level, just after `name:` or after `on:`), which applies to all jobs not specifying their own permissions. Since this workflow is primarily for CI and potentially publishing packages, a minimal permissions block would have `contents: read`, allowing the job to read repository files, and you may add others (like `packages: write`) only if strictly necessary for publishing to NuGet. For maximum safety and compatibility, start with the minimal block and let subsequent jobs/refs escalate permissions if needed.

**Required changes:**  
- Insert a `permissions:` block (e.g., `contents: read`) after the `name:` or after the `on:` block in `.github/workflows/ci.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
